### PR TITLE
fix(verified): let Phoenix handle missing routes

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -22,8 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        elixir: [1.13.4]
-        otp: [24.3.4]
+        elixir: [1.13.4, 1.14.4]
+        otp: [24.3.4, 25.3.1]
 
     name: Build and test
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## 0.1.0-alpha.3 (2023-05-05)
+## 0.1.0-alpha.4 (2023-05-04)
+
+### Bugfix
+* Do not raise during compilation when a route is not found by `Verified
+  Routes` extension. Phoenix will warn instead.
+
+
+## 0.1.0-alpha.3 (2023-05-03)
 
 ### Enhancements
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -15,7 +15,7 @@ You can install this library by adding it to your list of dependencies in `mix.e
 def deps do
   [
      ...other deps
-+    {:routex, "~> 0.1.0"}
++    {:routex, ">= 0.0.0"}
   ]
 end
 ```

--- a/ci.sh
+++ b/ci.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+mix compile --warnings-as-errors --force
+mix compile --warnings-as-errors
+mix credo --strict
+mix test
+mix docs

--- a/lib/routex/extension/alternative_getters.ex
+++ b/lib/routex/extension/alternative_getters.ex
@@ -79,13 +79,13 @@ defmodule Routex.Extension.AlternativeGetters do
   end
 
   defp helper_ast(path, sibling_routes, _env) do
-    pattern = Path.build_path_match(path)
+    pattern = Path.to_match_pattern(path)
 
     dynamic_paths =
       sibling_routes
       |> List.flatten()
       |> Enum.map(fn route ->
-        pattern = Path.build_path_match(route)
+        pattern = Path.to_match_pattern(route)
 
         # unset the :alternatives key as it is redundant
         attrs =

--- a/lib/routex/extension/attr_getters.ex
+++ b/lib/routex/extension/attr_getters.ex
@@ -58,7 +58,7 @@ defmodule Routex.Extension.AttrGetters do
 
     ast =
       for route <- routes do
-        pattern = Path.build_path_match(route.path)
+        pattern = Path.to_match_pattern(route.path)
 
         quote do
           def attrs(unquote(pattern)) do

--- a/lib/routex/extension/verified_routes.ex
+++ b/lib/routex/extension/verified_routes.ex
@@ -102,7 +102,7 @@ defmodule Routex.Extension.VerifiedRoutes do
     pattern_routes =
       routes
       |> Route.group_by_path()
-      |> Enum.map(fn {path, routes} -> {Path.build_path_match(path), routes} end)
+      |> Enum.map(fn {path, routes} -> {Path.to_match_pattern(path), routes} end)
       |> Map.new()
 
     original_sigil =
@@ -137,7 +137,7 @@ defmodule Routex.Extension.VerifiedRoutes do
   @doc false
   def sigil_callback(route, extra, pattern_routes, caller) do
     {:<<>>, _meta, segments} = route
-    pattern = Path.build_path_match(segments)
+    pattern = Path.to_match_pattern(segments)
     routes_matching_pattern = Map.get(pattern_routes, pattern, [])
 
     # Routex does not handle all routes. Return the original route if we find

--- a/lib/routex/path.ex
+++ b/lib/routex/path.ex
@@ -104,31 +104,31 @@ defmodule Routex.Path do
       iex> path_binary = "/products/:id/show/edit?_action=delete"
       iex> path_segments = ["products", ":id", "show", "edit?_garg=bar"]
       iex> path_ast = quote do: "/products/#{product}/show/edit?search=baz"
-      iex> build_path_match(path_binary)
+      iex> to_match_pattern(path_binary)
       ["products", {:arg0, [], Routex.Path}, "show", "edit"]
-      iex> build_path_match(path_segments)
+      iex> to_match_pattern(path_segments)
       ["products", {:arg0, [], Routex.Path}, "show", "edit"]
-      iex> build_path_match(path_ast)
+      iex> to_match_pattern(path_ast)
       ["products", {:arg0, [], Routex.Path}, "show", "edit"]
   """
 
-  def build_path_match({:<<>>, [], segments}) when is_list(segments) do
-    build_path_match(segments)
+  def to_match_pattern({:<<>>, [], segments}) when is_list(segments) do
+    to_match_pattern(segments)
   end
 
-  def build_path_match(segments) when is_list(segments) do
+  def to_match_pattern(segments) when is_list(segments) do
     {segments, _binding} =
       segments |> split() |> until_query() |> until_fragments() |> rewrite_segments()
 
     segments
   end
 
-  def build_path_match(path) when is_binary(path), do: build_path_match(path, :match)
+  def to_match_pattern(path) when is_binary(path), do: to_match_pattern(path, :match)
 
-  def build_path_match(%Phoenix.Router.Route{path: path, kind: kind}),
-    do: build_path_match(path, kind)
+  def to_match_pattern(%Phoenix.Router.Route{path: path, kind: kind}),
+    do: to_match_pattern(path, kind)
 
-  def build_path_match(path, kind) do
+  def to_match_pattern(path, kind) do
     url = URI.parse(path)
     path = url.path
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Routex.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/BartOtten/routex"
-  @version "0.1.0-alpha.3"
+  @version "0.1.0-alpha.4"
   @name "Phoenix Routes Extension Framework"
 
   def project do

--- a/test/routex/path_test.exs
+++ b/test/routex/path_test.exs
@@ -88,14 +88,14 @@ defmodule Routex.PathTest do
     end
   end
 
-  describe "build_path_match/1" do
+  describe "to_match_pattern/1" do
     test "builds uniform match for different types of input" do
       path_ast = quote do: "/products/#{product}/baz"
       path_binary = "/products/:id/baz"
       path_list = ["products", ":id", "baz"]
 
-      assert build_path_match(path_binary) == build_path_match(path_list)
-      assert build_path_match(path_binary) == build_path_match(path_ast)
+      assert to_match_pattern(path_binary) == to_match_pattern(path_list)
+      assert to_match_pattern(path_binary) == to_match_pattern(path_ast)
     end
 
     test "builds uniform match for different queries" do
@@ -105,7 +105,7 @@ defmodule Routex.PathTest do
         "/products/:id/show/edit?_action=update"
       ]
 
-      assert all_equal(paths, &build_path_match/1)
+      assert all_equal(paths, &to_match_pattern/1)
     end
 
     test "builds uniform match for different fragments" do
@@ -115,7 +115,7 @@ defmodule Routex.PathTest do
         "/products/:id/show/edit#update"
       ]
 
-      assert all_equal(paths, &build_path_match/1)
+      assert all_equal(paths, &to_match_pattern/1)
     end
 
     test "builds uniform match for different fragments (list)" do
@@ -125,7 +125,7 @@ defmodule Routex.PathTest do
         ["products", ":id", "baz", "#delete"]
       ]
 
-      assert all_equal(paths, &build_path_match/1)
+      assert all_equal(paths, &to_match_pattern/1)
     end
   end
 


### PR DESCRIPTION
Routex extension Verified Routes raised when it did not find a matching route in the route table. This is not unexpected though (static routes, unsupported routes) so we can simply return an original Phoenix Verified Route.