### PR TITLE
chore: raise minimum test coverage to 90%

### DIFF
--- a/coveralls.json
+++ b/coveralls.json
@@ -6,6 +6,6 @@
   "coverage_options": {
     "treat_no_relevant_lines_as_covered": false,
     "output_dir": "cover/",
-    "minimum_coverage": 40
+    "minimum_coverage": 90
   }
 }


### PR DESCRIPTION
Enforce a 90% minimum to ensure that our critical logic and error-handling paths are adequately tested without forcing unnecessary tests for trivial code. This threshold helps catch regressions early, promotes better design and maintainability, and provides an objective quality metric in our CI pipeline.