### PR TITLE
fix(processing): order not fully restored

### DIFF
--- a/test/routex/router_test.exs
+++ b/test/routex/router_test.exs
@@ -28,7 +28,8 @@ defmodule Routex.RouterTest.Dummy do
 
     preprocess_using RtxBackend do
       get "/", FakeController, :new
-      get "/routex", FakeController, :new
+      get "/routex/new", FakeController, :new
+      get "/routex/:id", FakeController, :new
     end
   end
 end
@@ -46,14 +47,20 @@ defmodule Routex.RouterTest do
   end
 
   test "all routes are present" do
-    assert [%{path: "/routex"}, %{path: "/"}] = Dummy.Router1.__routes__()
+    assert [%{path: "/"}, %{path: "/routex"}] = Dummy.Router1.__routes__()
   end
 
   test "works when all routes are wrapped" do
-    assert [%{path: "/routex"}, %{path: "/"}] = Dummy.Router2.__routes__()
+    assert [%{path: "/"}, %{path: "/routex/new"}, %{path: "/routex/:id"}] =
+             Dummy.Router2.__routes__()
   end
 
   test "routex plug is injected" do
     assert function_exported?(Dummy.Router1, :routex, 2)
+  end
+
+  test "routes order is preserved" do
+    assert [%{path: "/"}, %{path: "/routex/new"}, %{path: "/routex/:id"}] =
+             Dummy.Router2.__routes__()
   end
 end


### PR DESCRIPTION
The order of routes as in the router definition was not fully restored, causing unexpected mismatches for certain routes. After this commit the order is restored for both processed as non-processed routes.