### PR TITLE
Typo: Proces --> Process

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ stable release, refer to <a href="https://hexdocs.pm/routex/readme.html">HexDocs
   use of Elixirs superb pattern matching.
 
 * **No dependencies, no state**: Routex is unique in not depending on other
-  libraries and works out-of-the-box without proces state. An extension to
+  libraries and works out-of-the-box without process state. An extension to
   control third-party libraries that do rely on state such as Gettext is
   included.
 

--- a/lib/routex/utils.ex
+++ b/lib/routex/utils.ex
@@ -90,7 +90,7 @@ defmodule Routex.Utils do
         require Logger
 
         Logger.warning(
-          "#{caller.module}: No helper AST and no proces key `:rtx_branch` found. Fallback to `0`"
+          "#{caller.module}: No helper AST and no process key `:rtx_branch` found. Fallback to `0`"
         )
 
         0

--- a/test/routex/utils_test.exs
+++ b/test/routex/utils_test.exs
@@ -225,7 +225,7 @@ defmodule Routex.UtilsTest do
           assert result == 0
         end)
 
-      assert log =~ "No helper AST and no proces key `:rtx_branch` found. Fallback to `0`"
+      assert log =~ "No helper AST and no process key `:rtx_branch` found. Fallback to `0`"
     end
   end
 


### PR DESCRIPTION
As I'm seeing the warning too often, I figured I might fix the typo 😄

And then figure out, why I would see this warning just at one route.