### PR TITLE
Use URI.parse/1 to support list query params with []

### DIFF
--- a/lib/routex/extension/localize/phoenix/localize_phoenix_runtime.ex
+++ b/lib/routex/extension/localize/phoenix/localize_phoenix_runtime.ex
@@ -111,7 +111,7 @@ defmodule Routex.Extension.Localize.Phoenix.Runtime do
   """
   @spec handle_params(params, url, socket) :: {:cont, socket()}
   def handle_params(params, url, socket) do
-    uri = URI.new!(url)
+    uri = URI.parse(url)
     route_attrs = socket |> Attrs.get()
 
     conn_map = %{

--- a/test/routex/extension/localize_runtime_test.exs
+++ b/test/routex/extension/localize_runtime_test.exs
@@ -53,6 +53,22 @@ defmodule Routex.Extension.Localize.Phoenix.RuntimeTest do
 
       assert returned_socket.private.routex == expected
     end
+
+    test "works with list query params values with []" do
+      attrs = %{__backend__: DummyBackend, locale: "en-US"}
+      socket = %Phoenix.LiveView.Socket{private: %{routex: %{}}} |> Routex.Attrs.merge(attrs)
+
+      {:cont, returned_socket} =
+        Runtime.handle_params(%{}, "/some_url?items[]=1&items[]=2", socket)
+
+      expected = %{
+        __backend__: DummyBackend,
+        locale: "en-US",
+        runtime: %{language: "en", region: "US", territory: "US", locale: "en-US"}
+      }
+
+      assert returned_socket.private.routex == expected
+    end
   end
 
   describe "plug/3" do


### PR DESCRIPTION
Support list query param values with `[]` by using `URI.parse/1` instead of `URI.new!/1` to parse queries like `?items[]=1&items[]=2`

Reference https://hexdocs.pm/elixir/1.18.4/URI.html#parse/1-examples:
```
Another example is a URI with brackets in query strings. It is accepted by [parse/1](https://hexdocs.pm/elixir/1.18.4/URI.html#parse/1), it is commonly accepted by browsers, but it will be refused by [new/1](https://hexdocs.pm/elixir/1.18.4/URI.html#new/1)
```

Fixes #107 