### PR TITLE
fix(core): no matching function clause due to newline metadata.

### DIFF
--- a/lib/routex/branching.ex
+++ b/lib/routex/branching.ex
@@ -204,7 +204,7 @@ defmodule Routex.Branching do
         end
       end
       |> List.flatten()
-      |> Enum.uniq_by(fn {:->, [],
+      |> Enum.uniq_by(fn {:->, _meta,
                           [
                             [clause],
                             _extra


### PR DESCRIPTION
`{:->, [newlines: 1], [[clause], _extra]}` does not match `{:->, [], [[clause], _extra]}`. As we don't care about the metadata, we can simply ignore it.