### PR TITLE
fix(core): matchable type warning in Elixir 1.20+

### DIFF
--- a/lib/routex/extension/alternative_getters.ex
+++ b/lib/routex/extension/alternative_getters.ex
@@ -89,7 +89,7 @@ defmodule Routex.Extension.AlternativeGetters do
         require Record
         def alternatives(url) when is_binary(url), do: url |> Matchable.new() |> do_alternatives()
 
-        def alternatives(input) when Record.is_record(input, Matchable),
+        def alternatives(input) when Record.is_record(input, :matchable),
           do: input |> do_alternatives()
       end
 

--- a/lib/routex/extension/alternative_getters.ex
+++ b/lib/routex/extension/alternative_getters.ex
@@ -86,10 +86,11 @@ defmodule Routex.Extension.AlternativeGetters do
   def create_helpers(routes, _backend, _env) do
     guarded_defs =
       quote do
-        require Record
+        require Routex.Matchable
+
         def alternatives(url) when is_binary(url), do: url |> Matchable.new() |> do_alternatives()
 
-        def alternatives(input) when Record.is_record(input, :matchable),
+        def alternatives(input) when Routex.Matchable.is_matchable(input),
           do: input |> do_alternatives()
       end
 

--- a/lib/routex/extension/attr_getters.ex
+++ b/lib/routex/extension/attr_getters.ex
@@ -65,7 +65,7 @@ defmodule Routex.Extension.AttrGetters do
         """
         @spec attrs(url :: binary()) :: T.attrs()
         def attrs(url) when is_binary(url), do: url |> Matchable.new() |> do_attrs()
-        def attrs(input) when Record.is_record(input, Matchable), do: do_attrs(input)
+        def attrs(input) when Record.is_record(input, :matchable), do: do_attrs(input)
       end
 
     unguarded_defs =

--- a/lib/routex/extension/attr_getters.ex
+++ b/lib/routex/extension/attr_getters.ex
@@ -58,14 +58,14 @@ defmodule Routex.Extension.AttrGetters do
   def create_helpers(routes, _backend, _env) do
     guarded_defs =
       quote do
-        require Record
+        require Routex.Matchable
 
         @doc """
         Returns Routex attributes of given URL
         """
         @spec attrs(url :: binary()) :: T.attrs()
         def attrs(url) when is_binary(url), do: url |> Matchable.new() |> do_attrs()
-        def attrs(input) when Record.is_record(input, :matchable), do: do_attrs(input)
+        def attrs(input) when Routex.Matchable.is_matchable(input), do: do_attrs(input)
       end
 
     unguarded_defs =

--- a/lib/routex/matchable.ex
+++ b/lib/routex/matchable.ex
@@ -38,6 +38,9 @@ defmodule Routex.Matchable do
 
   defguardp is_ast(input) when is_tuple(input) and tuple_size(input) == 3
 
+  @doc "Returns true if `term` is a Matchable record"
+  defguard is_matchable(term) when is_record(term, :matchable)
+
   @doc """
   Converts a binary URL, `Phoenix.Router.Route` or (sigil) AST argument into a Matchable record.
 


### PR DESCRIPTION
The record is defined with defrecord(:matchable, ...) but the guards used the module name Matchable instead of the atom :matchable. 

This caused Elixir 1.20's type system to report incompatible types since Record.is_record(input, Matchable) checks for tag Routex.Matchable while the actual records have tag :matchable.

The correct pattern is already used in https://github.com/BartOtten/routex/blob/main/lib/routex/matchable.ex#L360-L369 where is_record(record, :matchable) is used with the atom.